### PR TITLE
Remove file association check in main.cpp

### DIFF
--- a/src/Gunz/main.cpp
+++ b/src/Gunz/main.cpp
@@ -562,29 +562,6 @@ LONG_PTR FAR PASCAL WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPara
 	return DefWindowProc(hWnd, message, wParam, lParam);
 }
 
-void CheckFileAssociation()
-{
-#define GUNZ_REPLAY_CLASS_NAME	"GunzReplay"
-
-#ifdef WIN32
-	char szValue[256];
-	if (!MRegistry::Read(HKEY_CLASSES_ROOT, "." GUNZ_REC_FILE_EXT, NULL, szValue))
-	{
-		MRegistry::Write(HKEY_CLASSES_ROOT, "." GUNZ_REC_FILE_EXT, NULL, GUNZ_REPLAY_CLASS_NAME);
-
-		char szModuleFileName[_MAX_PATH] = { 0, };
-		GetModuleFileName(NULL, szModuleFileName, _MAX_DIR);
-
-		char szCommand[_MAX_PATH];
-		sprintf_safe(szCommand, "\"%s\" \"%%1\"", szModuleFileName);
-
-		MRegistry::Write(HKEY_CLASSES_ROOT, GUNZ_REPLAY_CLASS_NAME "\\shell\\open\\command", NULL, szCommand);
-
-		SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_FLUSH, NULL, NULL);
-	}
-#endif
-}
-
 void UpgradeMrsFile()
 {
 	char temp_path[1024];
@@ -677,8 +654,6 @@ int PASCAL GunzMain(HINSTANCE this_inst, HINSTANCE prev_inst, LPSTR cmdline, int
 #endif
 
 	MSysInfoLog();
-
-	CheckFileAssociation();
 
 	// Initialize MZFileSystem - MUpdate
 	MRegistry::szApplicationName = APPLICATION_NAME;


### PR DESCRIPTION
It doesn't make any sense to have it there, as it:

 - requires elevated permissions (HKRT write), thereby forcing the entire client and other tools (such as screen capture software, e.g. OBS and ShadowPlay) to run as administrator
 - doesn't need to be performed during every startup; an external tool (such as an installer or a batch/PS script bundled with the client) should be responsible for that

Performing this change should be a step towards less headaches while streaming GunZ.