### PR TITLE
Fix weapon without delay (0 delay) & speed hack

### DIFF
--- a/src/CSCommon/Source/MCommandParameter.cpp
+++ b/src/CSCommon/Source/MCommandParameter.cpp
@@ -271,11 +271,7 @@ int MCommandParameterString::GetData(char* pData, int nSize)
 }
 int MCommandParameterString::SetData(const char* pData)
 {
-	//posible packet malformation crasher patch
-	unsigned short nLen = *( unsigned short* )pData;
-	if( !nLen || nLen > 1024u ) return 2;
-	if( IsBadReadPtr( ( pData + 2 ), nLen ) )return 2;
-	
+
 	if(m_Value!=NULL) 
 	{
 		delete[] m_Value;
@@ -468,11 +464,6 @@ int MCommandParameterBlob::GetData(char* pData, int nSize)
 }
 int MCommandParameterBlob::SetData(const char* pData)
 {
-	//possible packet malformation crasher patch
-	unsigned long nBlobSize = *( unsigned long* )pData;
-	if( !nBlobSize || nBlobSize > 1024u ) return 4;
-	unsigned long nBlobQtd = *( unsigned long* )( pData + 4 );
-	if( IsBadReadPtr( ( pData + 8 ), ( nBlobQtd * nBlobSize ) ) ) return 4;
 	
 	if(m_Value!=NULL) delete[] (char*)m_Value;
 

--- a/src/CSCommon/Source/MCommandParameter.cpp
+++ b/src/CSCommon/Source/MCommandParameter.cpp
@@ -271,6 +271,11 @@ int MCommandParameterString::GetData(char* pData, int nSize)
 }
 int MCommandParameterString::SetData(const char* pData)
 {
+	//posible packet malformation crasher patch
+	unsigned short nLen = *( unsigned short* )pData;
+	if( !nLen || nLen > 1024u ) return 2;
+	if( IsBadReadPtr( ( pData + 2 ), nLen ) )return 2;
+	
 	if(m_Value!=NULL) 
 	{
 		delete[] m_Value;
@@ -463,6 +468,12 @@ int MCommandParameterBlob::GetData(char* pData, int nSize)
 }
 int MCommandParameterBlob::SetData(const char* pData)
 {
+	//possible packet malformation crasher patch
+	unsigned long nBlobSize = *( unsigned long* )pData;
+	if( !nBlobSize || nBlobSize > 1024u ) return 4;
+	unsigned long nBlobQtd = *( unsigned long* )( pData + 4 );
+	if( IsBadReadPtr( ( pData + 8 ), ( nBlobQtd * nBlobSize ) ) ) return 4;
+	
 	if(m_Value!=NULL) delete[] (char*)m_Value;
 
 	memcpy(&m_nSize, pData, sizeof(m_nSize));

--- a/src/Gunz/ZCharacter.cpp
+++ b/src/Gunz/ZCharacter.cpp
@@ -2339,8 +2339,8 @@ bool ZCharacter::CheckValidShotTime(int nItemID, float fTime, ZItem* pItem)
 
 	if (GetLastShotItemID() == nItemID) {
 
-	// if time passed is less than item delay
-		if (fTime - GetLastShotTime() < (float)pItem->GetDesc()->m_nDelay/1000.0f) {
+	// if time passed is less than item delay or minimum delay
+		if (fTime - GetLastShotTime() < (float)pItem->GetDesc()->m_nDelay/1000.0f || fTime - GetLastShotTime() < 10/1000.0f) {
 			MMatchWeaponType nWeaponType = pItem->GetDesc()->m_nWeaponType;
 			if ( (MWT_DAGGER <= nWeaponType && nWeaponType <= MWT_DOUBLE_KATANA) &&
 				(fTime - GetLastShotTime() >= 0.23f) ) 

--- a/src/Gunz/ZCharacter.cpp
+++ b/src/Gunz/ZCharacter.cpp
@@ -1126,7 +1126,7 @@ void ZCharacter::UpdateVelocity(float fDelta)
 		forward.z=0;
 		Normalize(forward);
 
-		// ÃÖ´ë°ªÀ» ºñÀ²·Î Á¦¾îÇÑ´Ù.
+		// ìµœëŒ€ê°’ì„ ë¹„ìœ¨ë¡œ ì œì–´í•œë‹¤.
 		float run_speed = RUN_SPEED * fRatio;
 		float back_speed = BACK_SPEED * fRatio;
 		float stop_formax_speed = STOP_FORMAX_SPEED * (1/fRatio);  
@@ -1146,7 +1146,10 @@ void ZCharacter::UpdateVelocity(float fDelta)
 	if(IS_ZERO(Magnitude(m_Accel)) && m_bLand && !m_bWallJump && !m_bWallJump2 && !bTumble
 		&& (!m_bBlast || m_nBlastType != 1))
 		fSpeed = std::max(fSpeed-STOP_SPEED*fDelta,0.0f);
-
+	
+	//Speedhack fix
+	if(fSpeed > 1500.0f){fSpeed = 630.0f;}
+	
 	SetVelocity(dir.x*fSpeed, dir.y*fSpeed, GetVelocity().z);
 }
 
@@ -1501,7 +1504,7 @@ void ZCharacter::UpdateSound()
 		if(m_nWhichFootSound!=nCurrFoot && pMaterial) {	
 			if(m_nWhichFootSound==0)
 			{	
-				// ¿Ş¹ß
+				// ì™¼ë°œ
 				rvector pos = m_pVMesh->GetLFootPosition();
 				char *szSndName=g_pGame->GetSndNameFromBsp("man_fs_l", pMaterial);
 
@@ -1784,7 +1787,7 @@ void ZCharacter::OutputDebugString_CharacterState()
 
 	ZItem* pItem = m_Items.GetSelectedWeapon();
 
-	// ¼±ÅÃµÈ ¹«±â
+	// ì„ íƒëœ ë¬´ê¸°
 #define IF_SITEM_ENUM(a)		if(a==m_Items.GetSelectedWeaponType())		{ AddTextEnum(m_Items.GetSelectedWeaponType(),a); }
 #define ELSE_IF_SITEM_ENUM(a)	else if(a==m_Items.GetSelectedWeaponType())	{ AddTextEnum(m_Items.GetSelectedWeaponType(),a); }
 
@@ -2035,13 +2038,13 @@ void ZCharacter::InitMesh()
 	pMesh = ZGetMeshMgr()->Get(szMeshName);
 
 	if(!pMesh) {
-		mlog("AddCharacter ¿øÇÏ´Â ¸ğµ¨À» Ã£À»¼ö ¾øÀ½\n");
+		mlog("AddCharacter ì›í•˜ëŠ” ëª¨ë¸ì„ ì°¾ì„ìˆ˜ ì—†ìŒ\n");
 	}
 
 	int nVMID = g_pGame->m_VisualMeshMgr.Add(pMesh);
 
 	if(nVMID==-1) {
-		mlog("AddCharacter Ä³¸¯ÅÍ »ı¼º ½ÇÆĞ\n");
+		mlog("AddCharacter ìºë¦­í„° ìƒì„± ì‹¤íŒ¨\n");
 	}
 
 	m_nVMID = nVMID;
@@ -2310,8 +2313,8 @@ void ZCharacter::ChangeWeapon(MMatchCharItemParts nParts)
 
 	if (pSelectedItemDesc==NULL) {
 		m_Items.SelectWeapon(BackupParts);
-		mlog("¼±ÅÃµÈ ¹«±âÀÇ µ¥ÀÌÅÍ°¡ ¾ø´Ù.\n");
-		mlog("ZCharacter ¹«±â»óÅÂ¿Í RVisualMesh ÀÇ ¹«±â»óÅÂ°¡ Æ²·ÁÁ³´Ù\n");
+		mlog("ì„ íƒëœ ë¬´ê¸°ì˜ ë°ì´í„°ê°€ ì—†ë‹¤.\n");
+		mlog("ZCharacter ë¬´ê¸°ìƒíƒœì™€ RVisualMesh ì˜ ë¬´ê¸°ìƒíƒœê°€ í‹€ë ¤ì¡Œë‹¤\n");
 		return;
 	}
 
@@ -2342,11 +2345,11 @@ bool ZCharacter::CheckValidShotTime(int nItemID, float fTime, ZItem* pItem)
 			if ( (MWT_DAGGER <= nWeaponType && nWeaponType <= MWT_DOUBLE_KATANA) &&
 				(fTime - GetLastShotTime() >= 0.23f) ) 
 			{
-				// continue Valid... (Ä®Áú Á¤È®ÇÑ ½Ã°£ÃøÁ¤ÀÌ ¾î·Á¿ö ¸ÅÁ÷³Ñ¹ö»ç¿ë.
+				// continue Valid... (ì¹¼ì§ˆ ì •í™•í•œ ì‹œê°„ì¸¡ì •ì´ ì–´ë ¤ì›Œ ë§¤ì§ë„˜ë²„ì‚¬ìš©.
 			} else if ( (nWeaponType==MWT_DOUBLE_KATANA || nWeaponType==MWT_DUAL_DAGGER) &&
 				(fTime - GetLastShotTime() >= 0.11f) ) 
 			{
-				// continue Valid... (Ä®Áú Á¤È®ÇÑ ½Ã°£ÃøÁ¤ÀÌ ¾î·Á¿ö ¸ÅÁ÷³Ñ¹ö»ç¿ë.
+				// continue Valid... (ì¹¼ì§ˆ ì •í™•í•œ ì‹œê°„ì¸¡ì •ì´ ì–´ë ¤ì›Œ ë§¤ì§ë„˜ë²„ì‚¬ìš©.
 			} else {
 #ifdef _CHECKVALIDSHOTLOG
 				sprintf_safe(szLog, "IGNORE>> [%s] (%u:%u) Interval(%0.2f) Delay(%0.2f) \n", 

--- a/src/Gunz/ZMyCharacter.cpp
+++ b/src/Gunz/ZMyCharacter.cpp
@@ -1224,7 +1224,7 @@ void ZMyCharacter::ProcessShot()
 	
 	//0 delay hack fix
 	DWORD nWeaponDelay;
-	if((float)pRangeDesc->m_nDelay <= 10.0f){nWeaponDelay = 1000.0f;}
+	if((float)pRangeDesc->m_nDelay < 10.0f){nWeaponDelay = 9000.0f;}
 	else{nWeaponDelay = pRangeDesc->m_nDelay;}
 
 	m_fNextShotTimeType[nParts] = g_pGame->GetTime() + (float)(nWeaponDelay)*0.001f;

--- a/src/Gunz/ZMyCharacter.cpp
+++ b/src/Gunz/ZMyCharacter.cpp
@@ -1,6 +1,6 @@
 /*
-last modify : Á¤µ¿¼· @ 2006/3/16
-desc : ¹«±â »ç¿ë Å° Ä¿½ºÅÍ¸¶ÀÌÁî °ü·Ã
+last modify : ì •ë™ì„­ @ 2006/3/16
+desc : ë¬´ê¸° ì‚¬ìš© í‚¤ ì»¤ìŠ¤í„°ë§ˆì´ì¦ˆ ê´€ë ¨
 */
 
 #include "stdafx.h"
@@ -1221,7 +1221,11 @@ void ZMyCharacter::ProcessShot()
 		return;
 
 	MMatchItemDesc* pRangeDesc = pSelectedItem->GetDesc();
-	DWORD nWeaponDelay = pRangeDesc->m_nDelay;
+	
+	//0 delay hack fix
+	DWORD nWeaponDelay;
+	if((float)pRangeDesc->m_nDelay <= 10.0f){nWeaponDelay = 1000.0f;}
+	else{nWeaponDelay = pRangeDesc->m_nDelay;}
 
 	m_fNextShotTimeType[nParts] = g_pGame->GetTime() + (float)(nWeaponDelay)*0.001f;
 
@@ -2430,7 +2434,7 @@ void ZMyCharacter::UpdateCAFactor(float fDelta)
 ////////////////////////////////////////////////////////////
 ZDummyCharacter::ZDummyCharacter() : ZMyCharacter()
 {
-	// ·£´ıÀ¸·Î ¾Æ¹«°Å³ª ÀÔµµ·Ï ¸¸µç´Ù
+	// ëœë¤ìœ¼ë¡œ ì•„ë¬´ê±°ë‚˜ ì…ë„ë¡ ë§Œë“ ë‹¤
 #define _DUMMY_CHARACTER_PRESET		5
 	u32 nMeleePreset[_DUMMY_CHARACTER_PRESET] = { 1, 11, 3, 14, 15 };
 	u32 nPrimaryPreset[_DUMMY_CHARACTER_PRESET] = { 4010, 4013, 5004, 6004, 9001 };


### PR DESCRIPTION
Usually hacker change zItem weapon delay to 0 or fill with NOP the entire value using ASM debuger.
to fix that issue we simply check if delay is below a certain range; if so we change back his delay above an unplayable range.

