### PR TITLE
Major and minor memory leak fixes + server crash exploit

### DIFF
--- a/src/CSCommon/Include/MCommand.h
+++ b/src/CSCommon/Include/MCommand.h
@@ -115,14 +115,6 @@ public:
 	int GetSize() const;
 };
 
-template <typename ParamT, typename AllocT, typename... ArgsT>
-auto MakeParam(AllocT& Alloc, ArgsT&&... Args)
-{
-	auto p = (ParamT*)Alloc.allocate(sizeof(ParamT));
-	std::allocator_traits<AllocT>::construct(Alloc, p, Args...);
-	return p;
-}
-
 template <typename T>
 bool MCommand::SetData(const char* pData, MCommandManager* pCM, unsigned short nDataLen,
 	bool ReadSerial, T& Alloc)
@@ -170,69 +162,80 @@ bool MCommand::SetData(const char* pData, MCommandManager* pCM, unsigned short n
 		MCommandParameter* pParam = NULL;
 		switch (nParamType) {
 		case MPT_INT:
-			pParam = MakeParam<MCommandParameterInt>(Alloc);
+			pParam = new MCommandParameterInt;
 			break;
 		case MPT_UINT:
-			pParam = MakeParam<MCommandParameterUInt>(Alloc);
+			pParam = new MCommandParameterUInt;
 			break;
 		case MPT_FLOAT:
-			pParam = MakeParam<MCommandParameterFloat>(Alloc);
+			pParam = new MCommandParameterFloat;
 			break;
 		case MPT_STR:
-			if (std::is_same<T, std::allocator<uint8_t>>::value)
-				pParam = MakeParam<MCommandParameterString>(Alloc);
-			else
-				pParam = MakeParam<MCommandParameterStringCustomAlloc<T>>(Alloc, Alloc);
+			pParam = new MCommandParameterString;
+			{
+				unsigned short checkSize = 0;
+				memcpy(&checkSize, pData + nDataCount, sizeof(checkSize));
+				if (checkSize > nDataLen || checkSize == 0)
+				{
+					return false;
+				}
+			}
 			break;
 		case MPT_VECTOR:
-			pParam = MakeParam<MCommandParameterVector>(Alloc);
+			pParam = new MCommandParameterVector;
 			break;
 		case MPT_POS:
-			pParam = MakeParam<MCommandParameterPos>(Alloc);
+			pParam = new MCommandParameterPos;
 			break;
 		case MPT_DIR:
-			pParam = MakeParam<MCommandParameterDir>(Alloc);
+			pParam = new MCommandParameterDir;
 			break;
 		case MPT_BOOL:
-			pParam = MakeParam<MCommandParameterBool>(Alloc);
+			pParam = new MCommandParameterBool;
 			break;
 		case MPT_COLOR:
-			pParam = MakeParam<MCommandParameterColor>(Alloc);
+			pParam = new MCommandParameterColor;
 			break;
 		case MPT_UID:
-			pParam = MakeParam<MCommandParameterUID>(Alloc);
+			pParam = new MCommandParameterUID;
 			break;
 		case MPT_BLOB:
-			if (std::is_same<T, std::allocator<uint8_t>>::value)
-				pParam = MakeParam<MCommandParameterBlob>(Alloc);
-			else
-				pParam = MakeParam<MCommandParameterBlobCustomAlloc<T>>(Alloc, Alloc);
+			pParam = new MCommandParameterBlob;
+			{
+				unsigned int checkSize = 0;
+				memcpy(&checkSize, pData + nDataCount, sizeof(checkSize));
+				if (checkSize > nDataLen || checkSize == 0)
+				{
+					return false;
+				}
+			}
 			break;
 		case MPT_CHAR:
-			pParam = MakeParam<MCommandParameterChar>(Alloc);
+			pParam = new MCommandParameterChar;
 			break;
 		case MPT_UCHAR:
-			pParam = MakeParam<MCommandParameterUChar>(Alloc);
+			pParam = new MCommandParameterUChar;
 			break;
 		case MPT_SHORT:
-			pParam = MakeParam<MCommandParameterShort>(Alloc);
+			pParam = new MCommandParameterShort;
 			break;
 		case MPT_USHORT:
-			pParam = MakeParam<MCommandParameterUShort>(Alloc);
+			pParam = new MCommandParameterUShort;
 			break;
 		case MPT_INT64:
-			pParam = MakeParam<MCommandParameterInt64>(Alloc);
+			pParam = new MCommandParameterInt64;
 			break;
 		case MPT_UINT64:
-			pParam = MakeParam<MCommandParameterUInt64>(Alloc);
+			pParam = new MCommandParameterUInt64;
 			break;
 		case MPT_SVECTOR:
-			pParam = MakeParam<MCommandParameterShortVector>(Alloc);
+			pParam = new MCommandParameterShortVector;
 			break;
 		default:
 			//mlog("Error(MCommand::SetData): Wrong Param Type\n");
 			_ASSERT(false);		// Unknow Parameter!!!
 			return false;
+			break;
 		}
 
 		nDataCount += pParam->SetData(pData + nDataCount);

--- a/src/CSCommon/Include/MCommand.h
+++ b/src/CSCommon/Include/MCommand.h
@@ -171,7 +171,6 @@ bool MCommand::SetData(const char* pData, MCommandManager* pCM, unsigned short n
 			pParam = new MCommandParameterFloat;
 			break;
 		case MPT_STR:
-			pParam = new MCommandParameterString;
 			{
 				unsigned short checkSize = 0;
 				memcpy(&checkSize, pData + nDataCount, sizeof(checkSize));
@@ -180,6 +179,7 @@ bool MCommand::SetData(const char* pData, MCommandManager* pCM, unsigned short n
 					return false;
 				}
 			}
+			pParam = new MCommandParameterString;
 			break;
 		case MPT_VECTOR:
 			pParam = new MCommandParameterVector;
@@ -200,7 +200,6 @@ bool MCommand::SetData(const char* pData, MCommandManager* pCM, unsigned short n
 			pParam = new MCommandParameterUID;
 			break;
 		case MPT_BLOB:
-			pParam = new MCommandParameterBlob;
 			{
 				unsigned int checkSize = 0;
 				memcpy(&checkSize, pData + nDataCount, sizeof(checkSize));
@@ -209,6 +208,7 @@ bool MCommand::SetData(const char* pData, MCommandManager* pCM, unsigned short n
 					return false;
 				}
 			}
+			pParam = new MCommandParameterBlob;
 			break;
 		case MPT_CHAR:
 			pParam = new MCommandParameterChar;
@@ -235,7 +235,6 @@ bool MCommand::SetData(const char* pData, MCommandManager* pCM, unsigned short n
 			//mlog("Error(MCommand::SetData): Wrong Param Type\n");
 			_ASSERT(false);		// Unknow Parameter!!!
 			return false;
-			break;
 		}
 
 		nDataCount += pParam->SetData(pData + nDataCount);

--- a/src/MatchServer/MMatchServer.cpp
+++ b/src/MatchServer/MMatchServer.cpp
@@ -1120,39 +1120,50 @@ void MMatchServer::OnTunnelledP2PCommand(const MUID & Sender, const MUID & Recei
 		{
 			auto Cmd = MakeCmdFromSaneTunnelingBlob(Sender, MUID(0, 0), Blob, BlobSize);
 
-			v3 Pos, Dir;
-			ZC_SHOT_SP_TYPE Type;
-			int SelectedSlot;
-			if (!Cmd->GetParameter(&Pos, 1, MPT_POS))
-				return;
-			if (!Cmd->GetParameter(&Dir, 2, MPT_VECTOR))
-				return;
-			if (!Cmd->GetParameter(&Type, 3, MPT_INT))
-				return;
-			if (!Cmd->GetParameter(&SelectedSlot, 4, MPT_INT))
-				return;
-
-			auto Item = SenderObj->GetCharInfo()->m_EquipedItem.GetItem(MMatchCharItemParts(SelectedSlot));
-			if (!Item)
-				return;
-			auto ItemDesc = Item->GetDesc();
-			if (!ItemDesc)
-				return;
-
-			switch (Type)
+			if (Cmd)
 			{
-			case ZC_WEAPON_SP_ROCKET:
-				Stage->MovingWeaponMgr.AddRocket(SenderObj, ItemDesc, Pos, Dir);
-				break;
-			case ZC_WEAPON_SP_ITEMKIT:
-				Stage->MovingWeaponMgr.AddItemKit(SenderObj, ItemDesc, Pos, Dir);
-				break;
-			case ZC_WEAPON_SP_GRENADE:
-				auto GrenadeSpeed = 1200.f;
-				Stage->MovingWeaponMgr.AddGrenade(SenderObj, ItemDesc, Pos, Dir,
-					Dir * GrenadeSpeed + SenderObj->GetVelocity() + v3{ 0, 0, 300 });
-				break;
-			};
+				v3 Pos, Dir;
+				ZC_SHOT_SP_TYPE Type;
+				int SelectedSlot;
+				if (!Cmd->GetParameter(&Pos, 1, MPT_POS) ||
+					!Cmd->GetParameter(&Dir, 2, MPT_VECTOR) ||
+					!Cmd->GetParameter(&Type, 3, MPT_INT) ||
+					!Cmd->GetParameter(&SelectedSlot, 4, MPT_INT))
+				{
+					delete Cmd;
+					return;
+				}
+
+				auto Item = SenderObj->GetCharInfo()->m_EquipedItem.GetItem(MMatchCharItemParts(SelectedSlot));
+				if (!Item)
+				{
+					delete Cmd;
+					return;
+				}
+				auto ItemDesc = Item->GetDesc();
+				if (!ItemDesc)
+				{
+					delete Cmd;
+					return;
+				}
+
+				switch (Type)
+				{
+				case ZC_WEAPON_SP_ROCKET:
+					Stage->MovingWeaponMgr.AddRocket(SenderObj, ItemDesc, Pos, Dir);
+					break;
+				case ZC_WEAPON_SP_ITEMKIT:
+					Stage->MovingWeaponMgr.AddItemKit(SenderObj, ItemDesc, Pos, Dir);
+					break;
+				case ZC_WEAPON_SP_GRENADE:
+					auto GrenadeSpeed = 1200.f;
+					Stage->MovingWeaponMgr.AddGrenade(SenderObj, ItemDesc, Pos, Dir,
+						Dir * GrenadeSpeed + SenderObj->GetVelocity() + v3{ 0, 0, 300 });
+					break;
+				};
+
+				delete Cmd;
+			}
 		}
 		break;
 		case MC_PEER_DIE:


### PR DESCRIPTION
* Re-added sanity checks on mcommandparameterstring/blob
* Quick fix for memory leak - replace MakeParam with new()

Memory leak caused by MakeParam template skipping CMemPool::operator new, combined with the destructor inheritance on MCommandParameters - CMemPool::operator delete is called instead of deallocate or ::delete.
Therefore attempting to un-link memory that was never linked to the mempool in the first place.

Bottom line, MakeParam allocation and construction + the way MCommandParameters are destroyed = not re-using the memory, and not freeing it either