### PR TITLE
add GAME_FOCUS_CHECK to config.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /src/out/build/x64-Debug/.cmake/api/v1/reply
 /src/out/build/x64-Debug/CMakeFiles
 /src/out/build/x64-Debug
+/MatchServer.exe - Shortcut.lnk
+/Gunz.exe - Shortcut.lnk

--- a/src/CSCommon/Include/Config.h
+++ b/src/CSCommon/Include/Config.h
@@ -98,3 +98,6 @@
 
 // Controls whether the hit sound (fx_myhit) stacks when hitting multiple enemies at once.
 #define DONT_STACK_HITSOUNDS
+
+// Controls whether the game saves resourses when the main window is out of focus
+//#define GAME_FOCUS_CHECK

--- a/src/Mint2/Sample/HelloMint.cpp
+++ b/src/Mint2/Sample/HelloMint.cpp
@@ -32,8 +32,9 @@ LPDIRECT3DDEVICE8 g_dev = NULL;
 
 int		g_id;
 HWND	g_hAppWnd = NULL;
+#ifdef GAME_FOCUS_CHECK
 BOOL	g_bActive;
-
+#endif
 
 RFont g_Font;
 MEdit* g_pEdit = NULL;
@@ -309,11 +310,13 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 					break;
 				}
 			}       
-        
+
         case WM_ACTIVATEAPP:
         {
+			#ifdef GAME_FOCUS_CHECK
             // Determine whether app is being activated or not
             g_bActive = (BOOL)wParam ? TRUE : FALSE;
+			#endif
         }
         break;
 

--- a/src/RealSpace2/Source/RFrameWork.cpp
+++ b/src/RealSpace2/Source/RFrameWork.cpp
@@ -52,7 +52,9 @@ _NAMESPACE_REALSPACE2_BEGIN
 
 extern HWND g_hWnd;
 
-static bool g_bActive;
+#ifdef GAME_FOCUS_CHECK
+static bool g_bActiveg_bActive;
+#endif
 
 static RECT g_rcWindowBounds;
 static WNDPROC g_WinProc;
@@ -202,7 +204,9 @@ LRESULT FAR PASCAL WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam
 		if (wParam == TRUE) {
 			if (g_pFunctions[RF_ACTIVATE])
 				g_pFunctions[RF_ACTIVATE](NULL);
+			#ifdef GAME_FOCUS_CHECK
 			g_bActive = true;
+			#endif
 		}
 		else {
 			if (g_pFunctions[RF_DEACTIVATE])
@@ -212,7 +216,9 @@ LRESULT FAR PASCAL WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam
 				ShowWindow(hWnd, SW_MINIMIZE);
 				UpdateWindow(hWnd);
 			}
+			#ifdef GAME_FOCUS_CHECK
 			g_bActive = false;
+			#endif
 		}
 	}
 	break;
@@ -298,9 +304,10 @@ static int RenderLoop()
 
 			MCheckProfileCount();
 		}
-
+		#ifdef GAME_FOCUS_CHECK
 		if (!g_bActive)
 			Sleep(10);
+		#endif
 	} while (WM_QUIT != msg.message);
 
 	return static_cast<int>(msg.wParam);


### PR DESCRIPTION
Controls whether the game saves resourses when the main window is out of focus, it is now off instead of on by default. The resource saving made it difficult to debug with multi client as the out of focus windows would drop fps.