### PR TITLE
build-clean.bat does not delete install folder contents anymore

### DIFF
--- a/build-clean.bat
+++ b/build-clean.bat
@@ -1,5 +1,1 @@
 rmdir /S /Q build\win32
-rmdir /S /Q install\client
-rmdir /S /Q install\pdb
-rmdir /S /Q install\server
-rmdir /S /Q install\tools


### PR DESCRIPTION
This is useful because it allows us to keep the entire client inside install/client and server inside install/server and not lose the contents when we need to run build-clean.