### PR TITLE
Fix higher (incorrect) ping displaying in tab when spectating.

### DIFF
--- a/src/CSCommon/Include/HitRegistration.h
+++ b/src/CSCommon/Include/HitRegistration.h
@@ -92,7 +92,7 @@ bool PickHistory(typename ContainerT::value_type Exception,
 		if (HitParts == ZOH_NONE)
 			continue;
 
-		if (Obj->IsDie())
+		if (Obj->IsDead())
 			continue;
 
 		if (!HitObject || Magnitude(TempHitPos - src) < Magnitude(HitPos - src))

--- a/src/CSCommon/Source/BasicInfo.cpp
+++ b/src/CSCommon/Source/BasicInfo.cpp
@@ -86,7 +86,6 @@ bool UnpackNewBasicInfo(NewBasicInfo& nbi, const u8* pbi, size_t BlobSize)
 MCommandParameterBlob* PackNewBasicInfo(const CharacterInfo& Input, BasicInfoNetState& State, float Time)
 {
 	char buf[64];
-
 	size_t Size = 1;
 	auto Write = [&](auto&& Val)
 	{

--- a/src/Gunz/ZActor.cpp
+++ b/src/Gunz/ZActor.cpp
@@ -338,7 +338,7 @@ void ZActor::UpdateHeight(float fDelta)
 		}
 	}
 
-	if(GetDistToFloor()<0 && !IsDie())
+	if(GetDistToFloor()<0 && !IsDead())
 	{
 		float fAdjust=400.f*fDelta;
 		rvector diff=rvector(0,0,min(-GetDistToFloor(),fAdjust));
@@ -453,7 +453,7 @@ void ZActor::PostBasicInfo()
 	DWORD nNowTime = GetGlobalTimeMS();
 	if (GetInitialized() == false) return;
 
-	if(IsDie() && ZGetGame()->GetTime() - GetDeadTime()>5.f) return;
+	if(IsDead() && ZGetGame()->GetTime() - GetDeadTime()>5.f) return;
 	int nMoveTick = (ZGetGameClient()->GetAllowTunneling() == false) ? PEERMOVE_TICK : PEERMOVE_AGENT_TICK;
 
 	if ((int)(nNowTime - m_nLastTime[ACTOR_LASTTIME_BASICINFO]) >= nMoveTick)
@@ -622,7 +622,7 @@ void ZActor::RunTo(rvector& dir)
 	SetFlag(AF_MOVING, true);
 }
 
-bool ZActor::IsDie() 
+bool ZActor::IsDead() 
 { 
 	if(CheckFlag(AF_MY_CONTROL))
 		return CheckFlag(AF_DEAD); 
@@ -898,7 +898,7 @@ bool ZActor::IsCollideable()
 		ZA_ANIM_STATE nAnimState = m_Animation.GetCurrState();
 		if (nAnimState == ZA_ANIM_DIE) return false;
 
-		return (!IsDie());
+		return (!IsDead());
 	}
 
 	return m_Collision.bCollideable;

--- a/src/Gunz/ZActor.h
+++ b/src/Gunz/ZActor.h
@@ -149,7 +149,7 @@ public:
 	virtual ZOBJECTHITTEST HitTest(const rvector& origin, const rvector& to,
 		float fTime, rvector *pOutPos = NULL) override;
 
-	virtual bool IsDie() override;
+	virtual bool IsDead() override;
 
 	virtual MMatchTeam GetTeamID() const override { return MMT_BLUE; }
 

--- a/src/Gunz/ZBrain.cpp
+++ b/src/Gunz/ZBrain.cpp
@@ -434,7 +434,7 @@ ZObject* ZBrain::GetTarget()
 MQUEST_NPC_ATTACK ZBrain::CheckAttackable()
 {
 	ZObject* pTarget = GetTarget();
-	if ((pTarget == NULL) || (pTarget->IsDie())) return NPC_ATTACK_NONE;
+	if ((pTarget == NULL) || (pTarget->IsDead())) return NPC_ATTACK_NONE;
 
 	// 일단 근접 공격이 가능하면 근접 공격
 	if (m_pBody->GetNPCInfo()->nNPCAttackTypes & NPC_ATTACK_MELEE)
@@ -474,7 +474,7 @@ bool ZBrain::CheckSkillUsable(int *pnSkill, MUID *puidTarget, rvector *pTargetPo
 					itor != ZGetObjectManager()->end(); ++itor)
 				{
 					ZObject *pObject = itor->second;
-					if(pObject->IsDie()) continue;
+					if(pObject->IsDead()) continue;
 					if(ZGetGame()->IsAttackable(m_pBody,pObject)) continue;	// 적이면 넘어간다
 					if (pObject == m_pBody) continue;	// 자기자신이면 넘어간다.
 
@@ -545,7 +545,8 @@ bool ZBrain::FindTarget()
 		itor != ZGetCharacterManager()->end(); ++itor)
 	{
 		ZCharacter* pCharacter = (*itor).second;
-		if (pCharacter->IsDie()) continue;
+
+		if (pCharacter->IsDead()) continue;
 		
 		if (pCharacter->LostConnection())
 			continue;

--- a/src/Gunz/ZCharacter.cpp
+++ b/src/Gunz/ZCharacter.cpp
@@ -355,7 +355,7 @@ DWORD g_dwLastAnimationTime=GetGlobalTimeMS();
 void ZCharacter::SetAnimationLower(ZC_STATE_LOWER nAni)
 {
 	if (m_bInitialized == false) return;
-	if ((IsDie()) && (IsHero())) return;
+	if ((IsDead()) && (IsHero())) return;
 
 	if(nAni==m_AniState_Lower) return;
 	_ASSERT(nAni>=0 && nAni<ZC_STATE_LOWER_END);
@@ -388,7 +388,7 @@ void ZCharacter::SetAnimationLower(ZC_STATE_LOWER nAni)
 void ZCharacter::SetAnimationUpper(ZC_STATE_UPPER nAni)
 {
 	if (m_bInitialized == false) return;
-	if ((IsDie()) && (IsHero())) return;
+	if ((IsDead()) && (IsHero())) return;
 
 	if(nAni==m_AniState_Upper) 	return;
 
@@ -442,7 +442,7 @@ void ZCharacter::UpdateMotion(float fDelta)
 	// run , idle
 
 	// 자신의 타겟방향에 캐릭터의 방향을 맞춘다..
-	if (IsDie()) { //허리 변형 없다~
+	if (IsDead()) { //허리 변형 없다~
 
 		m_pVMesh->m_vRotXYZ.x = 0.f;
 		m_pVMesh->m_vRotXYZ.y = 0.f;
@@ -536,7 +536,7 @@ void ZCharacter::UpdateMotion(float fDelta)
 //{
 //	if (m_bInitialized==false) return;
 //
-//	if (IsDie()) {
+//	if (IsDead()) {
 //		m_pVMesh->m_vRotXYZ = { 0, 0, 0 };
 //		return;
 //	}
@@ -751,7 +751,7 @@ void ZCharacter::UpdateSpWeapon()
 	}
 }
 
-bool ZCharacter::IsMan() 
+bool ZCharacter::IsMan() const
 {
 	if(m_pVMesh) {
 		if(m_pVMesh->m_pMesh) {
@@ -827,7 +827,7 @@ void ZCharacter::OnDraw()
 	if (!m_bHero && ZGetGame()->GetMatch()->GetMatchType() == MMATCH_GAMETYPE_SKILLMAP)
 		MaxVisibility = 0.4f;
 
-	if(IsDie())
+	if(IsDead())
 	{
 		// If we are dead, fade out
 		constexpr auto TRAN_AFTER = 3.0f;
@@ -1040,7 +1040,7 @@ void ZCharacter::OnUpdate(float fDelta)
 
 	if( m_pVMesh && Enable_Cloth && m_pVMesh->isChestClothMesh() )
 	{
-		if(IsDie())
+		if(IsDead())
 		{
 			rvector force = rvector(0, 0, -150);
 			m_pVMesh->UpdateForce(force);
@@ -1082,7 +1082,7 @@ void ZCharacter::OnUpdate(float fDelta)
 		vProxyDirection = m_DirectionLower;
 	}
 
-	if(IsDie()) {
+	if(IsDead()) {
 		vProxyDirection = m_Direction;
 	}
 
@@ -1209,7 +1209,7 @@ void ZCharacter::UpdateVelocity(float fDelta)
 	if(fSpeed>max_speed)
 		fSpeed=max_speed;
 
-	bool bTumble= !IsDie() && (m_bTumble ||
+	bool bTumble= !IsDead() && (m_bTumble ||
 		(ZC_STATE_LOWER_TUMBLE_FORWARD<=m_AniState_Lower && m_AniState_Lower<=ZC_STATE_LOWER_TUMBLE_LEFT));
 
 	if(m_bLand && !m_bWallJump && !bTumble)
@@ -1486,7 +1486,7 @@ bool ZCharacter::GetHistory(rvector *pos, rvector *direction, float fTime, rvect
 	Info.Pos = pos;
 	Info.Dir = direction;
 	Info.CameraDir = cameradir;
-	return BasicInfoHistory.GetInfo(Info, fTime, std::ref(GetItemDesc), Sex, IsDie());
+	return BasicInfoHistory.GetInfo(Info, fTime, std::ref(GetItemDesc), Sex, IsDead());
 }
 
 void ZCharacter::GetPositions(v3* Head, v3* Foot, double Time)
@@ -1499,7 +1499,7 @@ void ZCharacter::GetPositions(v3* Head, v3* Foot, double Time)
 		BasicInfoHistoryManager::Info Info;
 		Info.Head = Head;
 		Info.Pos = Foot;
-		BasicInfoHistory.GetInfo(Info, Time, GetItemDesc, m_Property.nSex, IsDie());
+		BasicInfoHistory.GetInfo(Info, Time, GetItemDesc, m_Property.nSex, IsDead());
 		return;
 	}
 
@@ -1659,7 +1659,7 @@ void ZCharacter::UpdateSound()
 		}
 	}
 
-	if ( m_bDamaged && (!IsDie()) && (GetHP() < 30.f))
+	if ( m_bDamaged && (!IsDead()) && (GetHP() < 30.f))
 	{
 		if(GetProperty()->nSex==MMS_MALE)
 		{
@@ -2790,7 +2790,7 @@ bool ZCharacter::IsCollideable()
 {
 	if (m_Collision.bCollideable)
 	{
-		return ((!IsDie() && !m_bBlastDrop));
+		return ((!IsDead() && !m_bBlastDrop));
 	}
 
 	return m_Collision.bCollideable;
@@ -2798,7 +2798,7 @@ bool ZCharacter::IsCollideable()
 
 bool ZCharacter::IsAttackable()
 {
-	if (IsDie()) return false;
+	if (IsDead()) return false;
 	return true;
 }
 
@@ -2854,7 +2854,7 @@ ZOBJECTHITTEST ZCharacter::HitTest(const rvector& origin, const rvector& to,floa
 void ZCharacter::OnDamaged(ZObject* pAttacker, rvector srcPos, ZDAMAGETYPE damageType, MMatchWeaponType weaponType, float fDamage, float fPiercingRatio, int nMeleeType)
 {
 	if (m_bInitialized==false) return;
-	if (!IsVisible() || IsDie()) return;
+	if (!IsVisible() || IsDead()) return;
 
 	// If this isn't called on MyCharacter, it's unreliable predicted damage.
 	// Actual damage for other players is reported in HP/AP info packets.

--- a/src/Gunz/ZCharacter.h
+++ b/src/Gunz/ZCharacter.h
@@ -138,8 +138,8 @@ public:
 	}
 
 	bool isInvincible();
-
-	bool IsMan();
+	
+	bool IsMan() const;
 
 	virtual void OnUpdate(float fDelta) override;
 	void UpdateSpeed();
@@ -198,8 +198,7 @@ public:
 		m_fLastShotTime = fTime;
 	}
 
-
-	bool IsDie() override { return m_bDie; }
+	bool IsDead() override { return m_bDie; } const
 	auto IsAlive() const { return !m_bDie; }
 	void ForceDie() { SetHP(0); m_bDie = true; }
 

--- a/src/Gunz/ZCharacterManager.cpp
+++ b/src/Gunz/ZCharacterManager.cpp
@@ -107,7 +107,7 @@ int ZCharacterManager::GetLiveCount()
 	int nLiveCount = 0;
 	for(iterator i = begin(); i!=end(); i++){
 		ZCharacter* pCharacter = (*i).second;
-		if(pCharacter->IsDie()==false) nLiveCount++;
+		if(pCharacter->IsDead()==false) nLiveCount++;
 	}
 
 	return nLiveCount;

--- a/src/Gunz/ZCharacterObject.cpp
+++ b/src/Gunz/ZCharacterObject.cpp
@@ -476,7 +476,7 @@ void ZCharacterObject::DrawShadow()
 
 	if(!Shadow.has_value()) return;
 
-	if(!IsDie())
+	if(!IsDead())
 	{
 		float fSize = ZShadow::DefaultSize;
 		

--- a/src/Gunz/ZClothEmblem.cpp
+++ b/src/Gunz/ZClothEmblem.cpp
@@ -302,7 +302,7 @@ void ZClothEmblem::satisfyConstraints()
 				continue;
 			}
 
-			if (pCharacter->IsDie() && pCharacter->m_bBlastDrop && !pCharacter->IsVisible())
+			if (pCharacter->IsDead() && pCharacter->m_bBlastDrop && !pCharacter->IsVisible())
 			{
 				continue;
 			}

--- a/src/Gunz/ZCombatInterface.cpp
+++ b/src/Gunz/ZCombatInterface.cpp
@@ -352,7 +352,7 @@ void ZCombatInterface::DrawNPCName(MDrawContext* pDC)
 		rvector pos, screen_pos;
 		ZObject* pObject= (*itor).second;
 		if (!pObject->IsVisible()) continue;
-		if (pObject->IsDie()) continue;
+		if (pObject->IsDead()) continue;
 		if(!pObject->IsNPC()) continue;
 
 		ZActor *pActor = (ZActor*)pObject;
@@ -594,7 +594,7 @@ void ZCombatInterface::OnDraw(MDrawContext* pDC)
 							sprintf_safe( charName[ 0], "%s%d  %s", ZMsg( MSG_CHARINFO_LEVELMARKER),
 								pCharacter->GetProperty()->nLevel, pCharacter->GetUserName());
 
-						bIsChallengerDie = pCharacter->IsDie();
+						bIsChallengerDie = pCharacter->IsDead();
 					}
 
 					// Waiting 1
@@ -913,7 +913,7 @@ void ZCombatInterface::DrawSoloSpawnTimeMessage(MDrawContext* pDC)
 	{
 		if (!pMatch->IsWaitForRoundEnd())
 		{
-			if (Me->IsDie())
+			if (Me->IsDead())
 			{
 				char szMsg[128] = "";
 				int nRemainTime = pMatch->GetRemainedSpawnTime();
@@ -1162,7 +1162,7 @@ void ZCombatInterface::SetPickTarget(bool bPick, ZCharacter* pCharacter)
 		if(pCharacter->IsAdmin())
 			m_pTargetLabel->SetTextColor(ZCOLOR_ADMIN_NAME);
 
-		if (!bFriend == true && !pCharacter->IsDie()) 
+		if (!bFriend == true && !pCharacter->IsDead()) 
 		{
 			
 			strcpy_safe(m_szTargetName, pCharacter->GetUserName());
@@ -1270,7 +1270,7 @@ static void DrawNames(MDrawContext* pDC, ZCharacter* pTargetCharacter, bool Targ
 	{
 		if (!pCharacter) continue;
 		if (!pCharacter->IsVisible()) continue;
-		if (pCharacter->IsDie()) continue;
+		if (pCharacter->IsDead()) continue;
 		if (!pCharacter->IsRendered()) continue;
 		if (TargetTeamOnly)
 		{
@@ -1316,7 +1316,7 @@ void ZCombatInterface::DrawEnemyName(MDrawContext* pDC)
 
 	if (!pickinfo.pObject) return;
 	if (!IsPlayerObject(pickinfo.pObject)) return;
-	if (pickinfo.pObject->IsDie()) return;
+	if (pickinfo.pObject->IsDead()) return;
 
 	ZCharacter* pPickedCharacter = (ZCharacter*)pickinfo.pObject;
 
@@ -1650,7 +1650,7 @@ void ZCombatInterface::DrawScoreBoard(MDrawContext* pDC)
 		
 		pItem->nClanID = pCharacter->GetClanID();
 		pItem->nTeam = ZApplication::GetGame()->GetMatch()->IsTeamPlay() ? pCharacter->GetTeamID() : MMT_END;
-		pItem->bDeath = pCharacter->IsDie();
+		pItem->bDeath = pCharacter->IsDead();
 		if ( ZGetGameTypeManager()->IsQuestDerived( g_pGame->GetMatch()->GetMatchType()))
 			pItem->nExp = pCharacter->GetStatus()->nKills * 100;
 		else

--- a/src/Gunz/ZCombatQuestScreen.cpp
+++ b/src/Gunz/ZCombatQuestScreen.cpp
@@ -95,7 +95,7 @@ void ZCombatQuestScreen::DrawPlayer(MDrawContext* pDC, int index, ZCharacter* pC
 	MFont *pFont = MFontManager::Get("FONTa10b");
 	pDC->SetFont( pFont );
 	MCOLOR color = MCOLOR(0xFFFFFFFF);
-	if (pCharacter->IsDie()) color = MCOLOR(0xFF999999);
+	if (pCharacter->IsDead()) color = MCOLOR(0xFF999999);
 	else if (pCharacter == ZApplication::GetGame()->m_pMyCharacter) color = MCOLOR(0xFFEEEE00);
 	pDC->SetColor(color);
 

--- a/src/Gunz/ZEffectAniMesh.cpp
+++ b/src/Gunz/ZEffectAniMesh.cpp
@@ -248,7 +248,7 @@ bool ZEffectDash::Draw(u64 nTime)
 		if(pObserver->IsVisible())
 		{
 			rvector pos,dir;
-			pTarget->GetHistory(&pos,&dir,g_pGame->GetTime()-pObserver->GetDelay());
+			pTarget->GetHistory(&pos, &dir, g_pGame->GetTime() - pObserver->GetDelay());
 			m_Pos = pos;
 		}else
 			m_Pos = pTarget->GetPosition();
@@ -306,7 +306,7 @@ bool ZEffectPartsTypePos::Draw(u64 nTime)
 	if(pObj) {
 		if(pObj->m_pVMesh) {
 
-			if(pObj->IsDie())
+			if(pObj->IsDead())
 				return false;
 
 			m_Pos = pObj->m_pVMesh->GetBipTypePosition(m_type);

--- a/src/Gunz/ZEffectManager.cpp
+++ b/src/Gunz/ZEffectManager.cpp
@@ -2602,7 +2602,7 @@ void ZEffectManager::AddLostConIcon(ZObject* pObj)
 				ZCharacter* pChar = MDynamicCast(ZCharacter, pObj);
 
 				if( pChar ) {
-					if(pChar->IsDie()) return false;
+					if(pChar->IsDead()) return false;
 					if(!pChar->m_bLostConEffect) return false;
 					if(!pChar->m_bRendered)
 						return true;

--- a/src/Gunz/ZGameAction.cpp
+++ b/src/Gunz/ZGameAction.cpp
@@ -130,7 +130,7 @@ void ZGameAction::OnPeerSkill_LastShot(float fShotTime,ZCharacter *pOwnerCharact
 
 		rvector TargetPosition, TargetDir;
 
-		if (pTar->IsDie()) continue;
+		if (pTar->IsDead()) continue;
 
 		if (!pTar->GetHistory(&TargetPosition, &TargetDir, fShotTime)) continue;
 
@@ -229,7 +229,7 @@ void ZGameAction::OnPeerSkill_Uppercut(ZCharacter *pOwnerCharacter)
 
 		rvector TargetPosition,TargetDir;
 
-		if(pTar->IsDie()) continue;
+		if(pTar->IsDead()) continue;
 
 		if( !pTar->GetHistory(&TargetPosition,&TargetDir,fShotTime)) continue;
 
@@ -332,7 +332,7 @@ void ZGameAction::OnPeerSkill_Dash(ZCharacter *pOwnerCharacter)
 
 		rvector TargetPosition,TargetDir;
 
-		if(pTar->IsDie()) continue;
+		if(pTar->IsDead()) continue;
 
 		if( !pTar->GetHistory(&TargetPosition,&TargetDir,fShotTime)) continue;
 

--- a/src/Gunz/ZGameClient.cpp
+++ b/src/Gunz/ZGameClient.cpp
@@ -1649,7 +1649,7 @@ void ZGameClient::RequestGameSuicide()
 	ZMyCharacter* pMyCharacter = pGame->m_pMyCharacter;
 	if (!pMyCharacter) return;
 
-	if ((!pMyCharacter->IsDie()) && (pGame->GetMatch()->GetRoundState() == MMATCH_ROUNDSTATE_PLAY))
+	if ((!pMyCharacter->IsDead()) && (pGame->GetMatch()->GetRoundState() == MMATCH_ROUNDSTATE_PLAY))
 	{
 		pMyCharacter->SetLastDamageType(ZD_NONE);
 

--- a/src/Gunz/ZGameClient_Clan.cpp
+++ b/src/Gunz/ZGameClient_Clan.cpp
@@ -499,7 +499,7 @@ void ZGameClient::OnClanMsg(const char* szSenderName, const char* szMsg)
 
 	/*if ( ZApplication::GetGame())
 	{
-		if ( (ZApplication::GetGame()->GetMatch()->GetMatchType() == MMATCH_GAMETYPE_DUEL)	&& !ZApplication::GetGame()->m_pMyCharacter->IsDie())
+		if ( (ZApplication::GetGame()->GetMatch()->GetMatchType() == MMATCH_GAMETYPE_DUEL)	&& !ZApplication::GetGame()->m_pMyCharacter->IsDead())
 			sprintf_safe(szText, "%s(%s) : %s", ZMsg( MSG_CHARINFO_CLAN), szSenderName, ". . . . .");
 	}*/
 

--- a/src/Gunz/ZGameInterface.cpp
+++ b/src/Gunz/ZGameInterface.cpp
@@ -2582,7 +2582,7 @@ void ZGameInterface::ChangeWeapon(ZChangeWeaponType nType)
 
 	if (pChar->m_pVMesh == NULL) return;
 
-	if (pChar->IsDie()) return;
+	if (pChar->IsDead()) return;
 
 	if (m_pGame->GetMatch()->IsRuleGladiator() && !pChar->IsAdmin())
 		return;

--- a/src/Gunz/ZMatch.cpp
+++ b/src/Gunz/ZMatch.cpp
@@ -85,7 +85,7 @@ void ZMatch::ProcessRespawn()
 	if (!IsWaitForRoundEnd() && g_pGame->m_pMyCharacter)
 	{
 		static bool bLastDead = false;
-		if (g_pGame->m_pMyCharacter->IsDie())
+		if (g_pGame->m_pMyCharacter->IsDead())
 		{
 			if (bLastDead == false)
 			{
@@ -116,7 +116,7 @@ void ZMatch::ProcessRespawn()
 
 		}
 
-		bLastDead = g_pGame->m_pMyCharacter->IsDie();
+		bLastDead = g_pGame->m_pMyCharacter->IsDead();
 	}
 
 }
@@ -405,7 +405,7 @@ void ZMatch::GetTeamAliveCount(int* pnRedTeam, int* pnBlueTeam)
 			itor != g_pGame->m_CharacterManager.end(); ++itor)
 		{
 			ZCharacter* pCharacter = (*itor).second;
-			if (!pCharacter->IsDie())
+			if (!pCharacter->IsDead())
 			{
 				if (pCharacter->GetTeamID() == 0)
 				{
@@ -425,7 +425,7 @@ void ZMatch::GetTeamAliveCount(int* pnRedTeam, int* pnBlueTeam)
 
 void ZMatch::RespawnSolo(bool bForce)
 {
-	if ((!IsWaitForRoundEnd() && g_pGame->m_pMyCharacter->IsDie()) || bForce)
+	if ((!IsWaitForRoundEnd() && g_pGame->m_pMyCharacter->IsDead()) || bForce)
 	{
 		SoloSpawn();
 	}
@@ -476,7 +476,7 @@ int ZMatch::GetRemainedSpawnTime()
 	{
 		if (!IsWaitForRoundEnd())
 		{
-			if (g_pGame->m_pMyCharacter->IsDie())
+			if (g_pGame->m_pMyCharacter->IsDead())
 			{
 				if (m_nSoloSpawnTime < 0) return -1;
 				int nElapsedTime = m_nSoloSpawnTime;

--- a/src/Gunz/ZMiniMap.cpp
+++ b/src/Gunz/ZMiniMap.cpp
@@ -186,7 +186,7 @@ void ZMiniMap::OnDraw(MDrawContext* pDC)
 		itor != ZGetCharacterManager()->end(); ++itor)
 	{
 		ZCharacter* pCharacter = (*itor).second;
-		if(pCharacter->IsDie()) continue;
+		if(pCharacter->IsDead()) continue;
 
 		DWORD color = 0xfffff696;
 		if(ZApplication::GetGame()->GetMatch()->IsTeamPlay())
@@ -244,7 +244,7 @@ void ZMiniMap::OnDraw(MDrawContext* pDC)
 		ZCharacter* pCharacter = (*itor).second;
 
 		if (!pCharacter->IsVisible()) continue;
-		if (pCharacter->IsDie()) continue;
+		if (pCharacter->IsDead()) continue;
 		
 		rvector pos, screen_pos;
 		pos = pCharacter->GetPosition();

--- a/src/Gunz/ZModule_ElementalDamage.h
+++ b/src/Gunz/ZModule_ElementalDamage.h
@@ -17,7 +17,7 @@ public:
 		if (g_pGame->GetTime() > m_fNextDamageTime) {
 			m_fNextDamageTime += DAMAGE_DELAY;
 
-			if (pObj->IsDie()) {
+			if (pObj->IsDead()) {
 				if (pObj->m_pVMesh->GetVisibility() < 0.5f) {
 					Active = false;
 					return;
@@ -36,7 +36,7 @@ public:
 
 		if (g_pGame->GetTime() > m_fNextEffectTime) {
 
-			if (!pObj->IsDie())
+			if (!pObj->IsDead())
 			{
 				int nEffectLevel = GetEffectLevel() + 1;
 

--- a/src/Gunz/ZMyBotCharacter.cpp
+++ b/src/Gunz/ZMyBotCharacter.cpp
@@ -345,7 +345,7 @@ void ZMyBotCharacter::OnUpdate(float Delta)
 		UpdateAnimation();
 		UpdateVelocity(Delta);
 
-		if (GetDistToFloor() < 0 && !IsDie())
+		if (GetDistToFloor() < 0 && !IsDead())
 		{
 			float fAdjust = 400.f * Delta;
 			rvector diff = rvector(0, 0, min(-GetDistToFloor(), fAdjust));
@@ -370,7 +370,7 @@ bool ZMyBotCharacter::GetHistory(v3* Pos, v3* Dir, float Time, v3* CameraDir)
 	Info.Dir = Dir;
 	Info.CameraDir = CameraDir;
 
-	return RecordedHistory.GetInfo(Info, RelativeTime, std::ref(GetItemDesc), Sex, IsDie());
+	return RecordedHistory.GetInfo(Info, RelativeTime, std::ref(GetItemDesc), Sex, IsDead());
 }
 
 void ZMyBotCharacter::OnDamaged(ZObject* pAttacker, rvector srcPos, ZDAMAGETYPE damageType,
@@ -613,7 +613,7 @@ void ZMyBotCharacter::RenderCam()
 
 void ZMyBotCharacter::CheckDead()
 {
-	if (IsDie())
+	if (IsDead())
 		return;
 
 	MUID uidAttacker = MUID(0, 0);
@@ -642,7 +642,7 @@ void ZMyBotCharacter::CheckDead()
 	if (ZGetGameClient()->GetMatchStageSetting()->GetNetcode() == NetcodeType::ServerBased)
 		return;
 
-	if ((IsDie() == false) && (GetHP() <= 0))
+	if ((IsDead() == false) && (GetHP() <= 0))
 	{
 		if (uidAttacker == MUID(0, 0) && GetLastAttacker() != MUID(0, 0))
 			uidAttacker = GetLastAttacker();

--- a/src/Gunz/ZMyCharacter.cpp
+++ b/src/Gunz/ZMyCharacter.cpp
@@ -138,7 +138,7 @@ void ZMyCharacter::ProcessInput(float fDelta)
 	Normalize(forward);
 	CrossProduct(&right, rvector(0, 0, 1), forward);
 
-	if (!IsDie() && !m_bStun && !m_bBlastDrop && !m_bBlastStand)
+	if (!IsDead() && !m_bStun && !m_bBlastDrop && !m_bBlastStand)
 	{
 		bool ButtonPressed = false;
 
@@ -879,7 +879,7 @@ void ZMyCharacter::OnGadget_Hanging()
 		return;
 	};
 
-	if (IsDie() || m_bWallJump || m_bGuard || m_bDrop || m_bTumble || m_bSkill ||
+	if (IsDead() || m_bWallJump || m_bGuard || m_bDrop || m_bTumble || m_bSkill ||
 		m_bBlast || m_bBlastFall || m_bBlastDrop || m_bBlastStand || m_bBlastAirmove) return;
 	if (GetStateLower() == ZC_STATE_LOWER_JUMPATTACK) return;
 	if (m_bWallJump2 && (g_pGame->GetTime() - m_fJump2Time) < .40f) return;
@@ -949,7 +949,7 @@ void ZMyCharacter::ProcessGadget()
 
 	if (GetItems()->GetSelectedWeapon() == NULL) return;
 
-	if (IsDie() || m_bDrop || m_bBlast || m_bBlastDrop || m_bBlastStand)
+	if (IsDead() || m_bDrop || m_bBlast || m_bBlastDrop || m_bBlastStand)
 		return;
 
 	if (GetStateUpper() == ZC_STATE_UPPER_RELOAD || GetStateUpper() == ZC_STATE_UPPER_LOAD)
@@ -1027,7 +1027,7 @@ void ZMyCharacter::ProcessGadget()
 
 void ZMyCharacter::ProcessGuard()
 {
-	if (IsDie() || m_bWallJump || m_bDrop || m_bWallJump2 || m_bTumble ||
+	if (IsDead() || m_bWallJump || m_bDrop || m_bWallJump2 || m_bTumble ||
 		m_bBlast || m_bBlastFall || m_bBlastDrop || m_bBlastStand || m_bBlastAirmove ||
 		m_bSlash || m_bJumpSlash || m_bJumpSlashLanding) return;
 
@@ -1201,7 +1201,7 @@ void ZMyCharacter::ProcessShot()
 
 	if (m_bWallHang || m_bStun) return;
 
-	if (IsDie() || m_bDrop || m_bBlast || m_bBlastFall || m_bBlastDrop || m_bBlastStand || m_bSpMotion)
+	if (IsDead() || m_bDrop || m_bBlast || m_bBlastFall || m_bBlastDrop || m_bBlastStand || m_bSpMotion)
 		return;
 
 	if (GetStateUpper() == ZC_STATE_UPPER_RELOAD || GetStateUpper() == ZC_STATE_UPPER_LOAD)
@@ -1600,7 +1600,7 @@ void ZMyCharacter::OnUpdate(float fDelta)
 
 	fDelta = min(fDelta, 1.f);
 
-	if (IsDie() && ((m_bLand && m_bPlayDone))) {
+	if (IsDead() && ((m_bLand && m_bPlayDone))) {
 		SetVelocity(0, 0, 0);
 	}
 
@@ -1660,7 +1660,7 @@ void ZMyCharacter::OnUpdate(float fDelta)
 
 	UpdateCAFactor(fDelta);
 
-	if (GetDistToFloor() < 0 && !IsDie())
+	if (GetDistToFloor() < 0 && !IsDead())
 	{
 		float fAdjust = 400.f*fDelta;
 		rvector diff = rvector(0, 0, min(-GetDistToFloor(), fAdjust));
@@ -2133,7 +2133,7 @@ void ZMyCharacter::OnTumble(int nDir)
 {
 #define SWORD_DASH		1000.f
 #define GUN_DASH        900.f
-	if (IsDie() || m_bWallJump || m_bGuard || m_bDrop || m_bWallJump2 || m_bTumble || m_bWallHang ||
+	if (IsDead() || m_bWallJump || m_bGuard || m_bDrop || m_bWallJump2 || m_bTumble || m_bWallHang ||
 		m_bBlast || m_bBlastFall || m_bBlastDrop || m_bBlastStand || m_bBlastAirmove ||
 		m_bCharging || m_bSlash || m_bJumpSlash || m_bJumpSlashLanding ||
 		m_bStun || GetStateLower() == ZC_STATE_LOWER_UPPERCUT) return;
@@ -2566,7 +2566,7 @@ void ZMyCharacter::OnDelayedWork(ZDELAYEDWORKITEM& Item)
 		itor != ZGetCharacterManager()->end(); ++itor)
 		{
 			ZCharacter* pTar = (*itor).second;
-			if (this == pTar || pTar->IsDie()) continue;
+			if (this == pTar || pTar->IsDead()) continue;
 
 			rvector diff = GetPosition() + m_Direction*10.f - pTar->GetPosition();
 			diff.z *= .5f;

--- a/src/Gunz/ZMyCharacter.h
+++ b/src/Gunz/ZMyCharacter.h
@@ -201,7 +201,7 @@ public:
 	bool IsDirLocked() {
 		return (m_bSkill || m_bWallJump || m_bWallJump2 || m_bWallHang ||
 			m_bTumble || m_bBlast || m_bBlastStand || m_bBlastDrop)
-			&& !IsDie();
+			&& !IsDead();
 	}
 
 private:

--- a/src/Gunz/ZObject.cpp
+++ b/src/Gunz/ZObject.cpp
@@ -72,9 +72,9 @@ bool ZObject::GetHistory(rvector *pos, rvector *direction, float fTime, rvector*
 		return false;
 	
 	if (pos)
-		*pos=m_Position;
+		*pos = GetPosition();
 	if (direction)
-		*direction=m_Direction;
+		*direction = m_Direction;
 	if (cameradir)
 		*cameradir = m_Direction;
 

--- a/src/Gunz/ZObject.h
+++ b/src/Gunz/ZObject.h
@@ -103,7 +103,7 @@ public:
 	virtual float ColTest(const rvector& pos, const rvector& vec, float radius, rplane* out=0) { return 1.0f; }
 	virtual bool ColTest(const rvector& p1, const rvector& p2, float radius, float fTime);
 	virtual bool IsAttackable()	 { return true; }
-	virtual bool IsDie() { return false; }
+	virtual bool IsDead() { return false; }
 	virtual void SetDirection(const rvector& dir);
 	virtual bool IsGuardNonrecoilable() const { return false; }
 	virtual bool IsGuardRecoilable() const { return false; }

--- a/src/Gunz/ZObserver.cpp
+++ b/src/Gunz/ZObserver.cpp
@@ -13,7 +13,6 @@
 #include "ZGameClient.h"
 #include "ZRuleDuel.h"
 
-#define ZOBSERVER_DEFAULT_DELAY_TIME		0.2f
 
 bool ZObserverQuickTarget::ConvertKeyToIndex(char nKey, int* nIndex) 
 {
@@ -53,7 +52,7 @@ bool ZObserver::OnKeyEvent(bool bCtrl, char nKey)
 		}
 		
 		ZCharacter* pCharacter = g_pGame->m_CharacterManager.Find(uidTarget);
-		if (pCharacter && pCharacter->IsDie() == false)
+		if (pCharacter && pCharacter->IsDead() == false)
 		{
 			SetTarget(uidTarget);
 		}
@@ -109,7 +108,7 @@ void ZObserver::Show(bool bVisible)
 
 		if(SetFirstTarget())
 		{
-			m_fDelay=ZOBSERVER_DEFAULT_DELAY_TIME;
+			m_fDelay = ZOBSERVER_DEFAULT_DELAY_TIME;
 			ShowInfo(true);
 			m_bVisible = true;
 //			ZApplication::GetGameInterface()->SetCursorEnable(true);
@@ -205,7 +204,7 @@ bool ZObserver::SetFirstTarget()
 
 bool ZObserver::IsVisibleSetTarget(ZCharacter* pCharacter)
 {
-	if(pCharacter->IsDie()) return false;
+	if(pCharacter->IsDead()) return false;
 	if (pCharacter->IsAdminHide()) return false;
 	if (pCharacter->GetTeamID() == MMT_SPECTATOR) return false;
 
@@ -295,7 +294,7 @@ void ZObserver::OnDraw(MDrawContext* pDC)
 				strcpy_safe(charName[0], pCharacter->GetUserName());
 				fMaxHP[ 0] = pCharacter->GetProperty()->fMaxHP;
 				fMaxAP[ 0] = pCharacter->GetProperty()->fMaxAP;
-				if ( pCharacter->IsDie())
+				if ( pCharacter->IsDead())
 				{
 					nHP[ 0] = 0;
 					nAP[ 0] = 0;
@@ -319,7 +318,7 @@ void ZObserver::OnDraw(MDrawContext* pDC)
 				strcpy_safe(charName[1], pCharacter->GetUserName());
 				fMaxHP[ 1] = pCharacter->GetProperty()->fMaxHP;
 				fMaxAP[ 1] = pCharacter->GetProperty()->fMaxAP;
-				if ( pCharacter->IsDie())
+				if ( pCharacter->IsDead())
 				{
 					nHP[ 1] = 0;
 					nAP[ 1] = 0;
@@ -479,11 +478,11 @@ void ZObserver::OnDraw(MDrawContext* pDC)
 
 			if(pCharacter->IsAdminHide()) continue;
 		
-			if ( (pCharacter->GetTeamID()==4) && ( !pCharacter->IsDie()))
+			if ( (pCharacter->GetTeamID()==4) && ( !pCharacter->IsDead()))
 				nNumOfTotal++;
-			else if ( (pCharacter->GetTeamID()==MMT_RED) && ( !pCharacter->IsDie()))
+			else if ( (pCharacter->GetTeamID()==MMT_RED) && ( !pCharacter->IsDead()))
 				nNumOfRedTeam++;
-			else if ( (pCharacter->GetTeamID()==MMT_BLUE) && ( !pCharacter->IsDie()))
+			else if ( (pCharacter->GetTeamID()==MMT_BLUE) && ( !pCharacter->IsDead()))
 				nNumOfBlueTeam++;
 		}
 
@@ -534,7 +533,7 @@ void ZObserver::CheckDeadTarget()
 		return;
 	}
 
-	if (m_pTargetCharacter->IsDie())
+	if (m_pTargetCharacter->IsDead())
 	{
 		st_nDeadTime += nNowTime - nLastTime;
 	}

--- a/src/Gunz/ZObserver.h
+++ b/src/Gunz/ZObserver.h
@@ -20,6 +20,8 @@ enum ZObserverType
 
 #define ZFREEOBSERVER_RADIUS	30.f
 #define OBSERVER_QUICK_TAGGER_TARGET_KEY			'0'
+#define ZOBSERVER_DEFAULT_DELAY_TIME		0.2f
+
 
 class ZObserverQuickTarget {
 protected:

--- a/src/Gunz/ZQuest.cpp
+++ b/src/Gunz/ZQuest.cpp
@@ -624,8 +624,8 @@ bool ZQuest::OnRefreshPlayerStatus(MCommand* pCommand)
 		// 옵저버이거나 옵저버 예약상태를 푼다.
 		ZGetGame()->ReleaseObserver();
 
-		// 죽어있으면 리스폰
-		if (ZGetGame()->m_pMyCharacter->IsDie())
+		// If you're dead, respawn.
+		if (ZGetGame()->m_pMyCharacter->IsDead())
 		{
 			ZGetGame()->GetMatch()->RespawnSolo();
 		}

--- a/src/Gunz/ZRuleBerserker.cpp
+++ b/src/Gunz/ZRuleBerserker.cpp
@@ -83,7 +83,7 @@ void ZRuleBerserker::AssignBerserker(MUID& uidBerserker)
 		ZGetEffectManager()->AddBerserkerIcon(pBerserkerChar);
 		pBerserkerChar->SetTagger(true);
 		
-		if (!pBerserkerChar->IsDie())
+		if (!pBerserkerChar->IsDead())
 		{
 			float fMaxHP = pBerserkerChar->GetProperty()->fMaxHP;
 			float fMaxAP = pBerserkerChar->GetProperty()->fMaxAP;
@@ -119,7 +119,7 @@ void ZRuleBerserker::BonusHealth(ZCharacter* pBerserker)
 {
 	if (pBerserker)
 	{
-		if (pBerserker->IsDie()) return;
+		if (pBerserker->IsDead()) return;
 
 		float fBonusAP = 0.0f;
 		float fBonusHP = BERSERKER_BONUS_HEALTH;

--- a/src/Gunz/ZSkill.cpp
+++ b/src/Gunz/ZSkill.cpp
@@ -40,7 +40,7 @@ ZSkillDesc::ZSkillDesc()
 
 bool ZSkillDesc::IsEffectiveTo(ZObject *pTarget)
 {
-	if(pTarget->IsDie()) return false;
+	if(pTarget->IsDead()) return false;
 
 	ZModule_HPAP *pModule = (ZModule_HPAP*)pTarget->GetModule(ZMID_HPAP);
 
@@ -379,7 +379,7 @@ bool ZSkill::Update(float fElapsed)
 
 		for(ZObjectManager::iterator i = ZGetObjectManager()->begin();i!=ZGetObjectManager()->end();i++) {
 			ZObject *pTarget = i->second;
-			if(pTarget->IsDie()) continue;
+			if(pTarget->IsDead()) continue;
 			float fDamage = m_pDesc->nModDoT;
 			if(CheckRange(pTarget->GetPosition(),pTarget) && m_pDesc->CheckResist(pTarget,&fDamage)) {
 				if(g_pGame->IsAttackable(m_pOwner,pTarget)) {
@@ -474,7 +474,7 @@ void ZSkill::LastExecute(const MUID& uidTarget, const rvector& targetPos )
 {
 	for(ZObjectManager::iterator i = ZGetObjectManager()->begin();i!=ZGetObjectManager()->end();i++) {
 		ZObject *pTarget = i->second;
-		if(pTarget->IsDie()) continue;
+		if(pTarget->IsDead()) continue;
 		float fDamage = m_pDesc->nModLastDamage;
 		if(CheckRange(pTarget->GetPosition(),pTarget) && m_pDesc->CheckResist(pTarget,&fDamage)) {
 			if(g_pGame->IsAttackable(m_pOwner,pTarget)) {
@@ -545,7 +545,7 @@ void ZSkill::Use(const MUID& uidTarget, const rvector& targetPos)
 		{
 			ZObject *pObject = i->second;
 
-			if(pObject->IsDie())
+			if(pObject->IsDead())
 				continue;
 
 			float fDamage = m_pDesc->nModDamage;

--- a/src/Gunz/ZWeapon.cpp
+++ b/src/Gunz/ZWeapon.cpp
@@ -629,7 +629,7 @@ void ZWeaponFlashBang::Explosion()
 		return;
 	}
 
-	if (g_pGame->m_pMyCharacter->IsDie())
+	if (g_pGame->m_pMyCharacter->IsDead())
 	{
 		return;
 	}

--- a/src/Gunz/ZWorldItem.cpp
+++ b/src/Gunz/ZWorldItem.cpp
@@ -252,7 +252,7 @@ void ZWorldItemManager::update()
 {
 	ZCharacter* pCharacter = g_pGame->m_pMyCharacter;
 	
-	if( pCharacter==NULL||pCharacter->IsDie() ) return; 
+	if( pCharacter==NULL||pCharacter->IsDead() ) return; 
 	
 	for(auto* pItem : MakePairValueAdapter(mItemList))
 	{

--- a/src/MatchServer/MMatchObject.h
+++ b/src/MatchServer/MMatchObject.h
@@ -473,7 +473,7 @@ public:
 	bool GetEnterBattle() const		{ return m_bEnterBattle; }
 	void SetEnterBattle(bool bEnter){ m_bEnterBattle = bEnter; }
 	bool CheckAlive() const			{ return m_bAlive; }
-	bool IsDie() const				{ return !m_bAlive; }
+	bool IsDead() const				{ return !m_bAlive; }
 	bool IsAlive() const			{ return m_bAlive; }
 	void SetAlive(bool bVal)		{ m_bAlive = bVal; }
 	void SetKillCount(unsigned int nKillCount) { m_nKillCount = nKillCount; }


### PR DESCRIPTION
Spectating player and alive player watching spectating player see incorrect ping.
This is a dirty fix and should be fixed properly if possible (get wrong ping due to the spectator delay being included in the timestamp and subtract it).
Note that when running local matchserver and multiple clients this can cause to show negative pings, like -5, I'm not sure what is the cause of that but I wasn't able to reproduce that with a remote matchserver.

rename isDie() to isDead() because what the heck Maiet.