### PR TITLE
fix/zplayerlistbox-color-name

### DIFF
--- a/src/Gunz/ZPlayerListBox.h
+++ b/src/Gunz/ZPlayerListBox.h
@@ -43,7 +43,9 @@ public:
 	}
 
 	void SetColor(MCOLOR c) { m_Color = c; }
-	MCOLOR GetColor() const { return m_Color; }
+	const MCOLOR GetColor() { 
+		return m_Color; 
+	}
 	const MUID& GetUID() const { return m_PlayerUID; }
 
 	MUID				m_PlayerUID{};


### PR DESCRIPTION
For whatever reason, GetColor needs a body here. Tested and working.
![GunZ000](https://user-images.githubusercontent.com/23348770/164340723-888edfea-68cc-464c-b5f0-55479e0d496b.png)
