### PR TITLE
fix/tdm-premature-end

### DIFF
--- a/src/MatchServer/MMatchRuleDeathMatch.cpp
+++ b/src/MatchServer/MMatchRuleDeathMatch.cpp
@@ -26,6 +26,20 @@ bool MMatchRuleTeamDeath::OnRun()
 
 void MMatchRuleTeamDeath::OnRoundBegin()
 {
+	//dirty fix for tdm rounds ending while players are still alive.
+	//this ensures m_bAlive is true for each player when the round begins.
+	for (auto i = m_pStage->GetObjBegin(); i != m_pStage->GetObjEnd(); i++)
+	{
+		MMatchObject* pObj = i->second;
+		if (pObj->GetEnterBattle() == true)
+		{
+			if (pObj->GetTeam() == MMT_RED || pObj->GetTeam() == MMT_BLUE)
+			{
+				if (!pObj->IsAlive())
+					pObj->SetAlive(true);
+			}
+		}
+	}
 	MMatchRule::OnRoundBegin();
 }
 


### PR DESCRIPTION
this is a dirty fix for tdm matches ending prematurely. the real cause of this bug is still unknown.

force set m_bAlive to true on Round begin.